### PR TITLE
The int16 bit data is converted to int64 bit in cal_file_size. in readrdi.py

### DIFF
--- a/src/pyadps/utils/readrdi.py
+++ b/src/pyadps/utils/readrdi.py
@@ -326,7 +326,7 @@ class FileHeader:
         """
         file_stats = os.stat(self.filename)
         sys_file_size = file_stats.st_size
-        cal_file_size = sum(self.bytes) + 2 * len(self.bytes)
+        cal_file_size = sum((self.bytes).astype(int)) + 2 * len(self.bytes)
 
         check = dict()
 


### PR DESCRIPTION
tested in anaconda environment. 