### PR TITLE
feat(profile-ops): regrid options, trimends fix, trim UI overhaul, and plot improvements

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,43 +6,60 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'pyadps'
-copyright = '2024, p-amol'
-author = 'p-amol'
+project = "pyadps"
+copyright = "2024, p-amol"
+author = "p-amol"
 
 # -- General configuration ---------------------------------------------------
 
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 extensions = [
-    'sphinx.ext.duration',
-    'sphinx.ext.doctest',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.viewcode',
-    'autoapi.extension',
-    'myst_nb',
+    "sphinx.ext.duration",
+    "sphinx.ext.doctest",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.viewcode",
+    "myst_nb",
+    "sphinx_rtd_theme",  # ReadTheDocs theme
+    "autoapi.extension",
 ]
+
+# -- MyST configuration ------------------------------------------------------
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".ipynb": "myst-nb",
+}
+
+myst_enable_extensions = [
+    "colon_fence",  # ::: directive syntax
+    "deflist",  # definition lists
+    "fieldlist",  # :param: style fields
+]
+
+# -- MyST-NB configuration ---------------------------------------------------
+nb_execution_mode = "off"  # "auto", "force", "cache", or "off"
+execution_excludepatterns = [
+    "**.ipynb"
+]  # Prevent execution for specific files (if needed)
+
+# -- AutoAPI configuration ---------------------------------------------------
 
 autoapi_type = "python"
 autoapi_add_toctree_entry = False
-autoapi_dirs = ['../../src']
-autodoc_mock_imports = ['numpy', 'pandas', 'matplotlib', 'pyadps']
-templates_path = ['_templates']
+autoapi_dirs = ["../../src"]
+autodoc_mock_imports = ["numpy", "pandas", "matplotlib", "pyadps"]
+templates_path = ["_templates"]
 exclude_patterns = []
-
-# Myst-NB configuration
-jupyter_execute_notebooks = "off"  # Do not execute cells
-execution_excludepatterns = ["**.ipynb"]  # Prevent execution for specific files (if needed)
-
+autoapi_keep_files = False  # set True to inspect generated .rst files
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 # html_theme_options = {
 #     "collapse_navigation": True,  # Optional: Collapse navigation items
 #     "navigation_depth": 2,        # Controls ToC depth globally
 # }
 
-html_static_path = ['_static']
+html_static_path = ["_static"]

--- a/src/pyadps/__init__.py
+++ b/src/pyadps/__init__.py
@@ -19,7 +19,6 @@ Submodules:
     io: Low-level file reading (binary_reader, pd0_parser)
     pipeline: Six-step processing pipeline
     config: Configuration management
-    legacy: v0.4.0 code (deprecated)
     pages: Streamlit UI components
 
 Example:
@@ -109,7 +108,12 @@ def load_example(name: str = "demo"):
     return read(str(path))
 
 
-__version__ = "1.0.0"
+try:
+    from importlib.metadata import version as _get_version
+
+    __version__ = _get_version("pyadps")
+except Exception:  # pragma: no cover
+    __version__ = "0.0.0.dev0"  # pragma: no cover
 
 __all__ = [
     "read",
@@ -122,7 +126,6 @@ __all__ = [
     "read_percent_good",
     "read_status",
     "io",
-    "legacy",
     "pages",
     "ProcessedDataset",
     "ProcessingConfig",

--- a/src/pyadps/pages/06_Profile_Operations.py
+++ b/src/pyadps/pages/06_Profile_Operations.py
@@ -145,6 +145,31 @@ def status_color_map(value: object) -> str:
     return ""
 
 
+def _trim_has_effect() -> bool:
+    n = get_total_ensembles()
+    return st.session_state.trim_start_ens > 0 or st.session_state.trim_end_ens < n - 1
+
+
+def _trim_to_counts():
+    """Convert absolute ensemble indices to (start_count, end_count) for runner.trim_ensembles()."""
+    n = get_total_ensembles()
+    start_ens = int(st.session_state.trim_start_ens)
+    end_ens = int(st.session_state.trim_end_ens)
+    start_count = start_ens if start_ens > 0 else None
+    end_count = (n - 1 - end_ens) if end_ens < n - 1 else None
+    return start_count, end_count
+
+
+def _trim_trimends():
+    """Return trimends (start_idx, end_exclusive) for runner.regrid(), or None if no trim."""
+    if not _trim_has_effect():
+        return None
+    return (
+        int(st.session_state.trim_start_ens),
+        int(st.session_state.trim_end_ens) + 1,
+    )
+
+
 # =============================================================================
 # PLOTTING FUNCTIONS
 # =============================================================================
@@ -154,7 +179,7 @@ def plot_heatmap(
     data: np.ndarray,
     title: str,
     mask_data: np.ndarray = None,
-    colorscale: str = "balance",
+    colorscale="balance",
 ) -> None:
     """Create a heatmap plot for 2D data (cell x ensemble)."""
     n_ensembles = get_total_ensembles()
@@ -206,6 +231,8 @@ def plot_heatmap(
         yaxis_title="Cell",
         height=400,
     )
+    fig.update_xaxes(showline=True, linewidth=1, linecolor="gray", mirror=True)
+    fig.update_yaxes(showline=True, linewidth=1, linecolor="gray", mirror=True)
 
     st.plotly_chart(fig, use_container_width=True)
 
@@ -287,61 +314,6 @@ def plot_trim_ends(
     st.plotly_chart(fig, use_container_width=True)
 
 
-def plot_mask_comparison(original_mask: np.ndarray, preview_mask: np.ndarray) -> None:
-    """Plot side-by-side comparison of original and preview masks."""
-    n_ensembles = get_total_ensembles()
-    n_cells = get_total_cells()
-
-    # Ensure 2D masks for plotting
-    if original_mask.ndim == 3:
-        orig_2d = original_mask[0, :, :]
-    else:
-        orig_2d = original_mask
-
-    if preview_mask.ndim == 3:
-        prev_2d = preview_mask[0, :, :]
-    else:
-        prev_2d = preview_mask
-
-    fig = make_subplots(
-        rows=1,
-        cols=2,
-        subplot_titles=["Original Mask", "Preview Mask"],
-    )
-
-    # Original mask
-    fig.add_trace(
-        go.Heatmap(
-            z=orig_2d,
-            x=np.arange(n_ensembles),
-            y=np.arange(n_cells),
-            colorscale="greys",
-            showscale=False,
-        ),
-        row=1,
-        col=1,
-    )
-
-    # Preview mask
-    fig.add_trace(
-        go.Heatmap(
-            z=prev_2d,
-            x=np.arange(n_ensembles),
-            y=np.arange(n_cells),
-            colorscale="greys",
-            showscale=False,
-        ),
-        row=1,
-        col=2,
-    )
-
-    fig.update_layout(height=400, title_text="Mask Comparison")
-    fig.update_xaxes(title="Ensemble")
-    fig.update_yaxes(title="Cell")
-
-    st.plotly_chart(fig, use_container_width=True)
-
-
 # =============================================================================
 # SESSION STATE INITIALIZATION
 # =============================================================================
@@ -351,9 +323,9 @@ if "profile_initialized" not in st.session_state:
     st.session_state.profile_applied = False
     st.session_state.profile_preview_run = False
 
-    # Trim settings
-    st.session_state.trim_start = 0
-    st.session_state.trim_end = 0
+    # Trim settings (absolute ensemble indices, inclusive)
+    st.session_state.trim_start_ens = 0
+    st.session_state.trim_end_ens = max(0, get_total_ensembles() - 1)
 
     # Side lobe settings
     st.session_state.apply_side_lobe = False
@@ -459,60 +431,58 @@ with tab1:
 
         st.write("---")
 
-        # Trim start
-        trim_start = st.slider(
-            "Trim from start",
+        # First valid ensemble (inclusive)
+        trim_start_ens = st.number_input(
+            "First valid ensemble",
             min_value=0,
-            max_value=min(int(ens_range), n_ensembles - 1),
-            value=int(st.session_state.trim_start),
-            key="trim_start_slider",
+            max_value=n_ensembles - 1,
+            value=int(st.session_state.trim_start_ens),
+            key="trim_start_ens_input",
+            help="First ensemble index to keep (0-based). Ensembles before this are trimmed.",
         )
-        st.session_state.trim_start = trim_start
+        st.session_state.trim_start_ens = trim_start_ens
 
-        # Trim end
-        trim_end = st.slider(
-            "Trim from end",
+        # Last valid ensemble (inclusive)
+        trim_end_ens = st.number_input(
+            "Last valid ensemble",
             min_value=0,
-            max_value=min(int(ens_range), n_ensembles - 1),
-            value=int(st.session_state.trim_end),
-            key="trim_end_slider",
+            max_value=n_ensembles - 1,
+            value=int(st.session_state.trim_end_ens),
+            key="trim_end_ens_input",
+            help="Last ensemble index to keep (0-based, inclusive). Ensembles after this are trimmed.",
         )
-        st.session_state.trim_end = trim_end
+        st.session_state.trim_end_ens = trim_end_ens
 
         st.write("---")
 
+        st.write(f"**Ensembles to keep:** `{trim_start_ens}` to `{trim_end_ens}`")
         st.write(
-            f"**Ensembles to keep:** `{trim_start}` to `{n_ensembles - trim_end - 1}`"
-        )
-        st.write(
-            f"**Total kept:** `{n_ensembles - trim_start - trim_end}` of `{n_ensembles}`"
+            f"**Total kept:** `{trim_end_ens - trim_start_ens + 1}` of `{n_ensembles}`"
         )
 
         # Preview button
         if st.button("👁️ Preview Trim", key="preview_trim"):
-            # Reset preview processor and apply trim
-            # st.session_state.preview_profile_proc = ProcessedDataset(proc.dataset)
-            # preview_profile_proc = st.session_state.preview_profile_proc
-
-            if trim_start > 0 or trim_end > 0:
+            start_count, end_count = _trim_to_counts()
+            if start_count is not None or end_count is not None:
                 runner = preview_profile_proc.get_profile_operation_runner()
-                runner.trim_ensembles(
-                    start=trim_start if trim_start > 0 else None,
-                    end=trim_end if trim_end > 0 else None,
-                )
+                runner.trim_ensembles(start=start_count, end=end_count)
                 preview_profile_proc.commit_runner(runner)
 
             st.session_state.profile_preview_run = True
             st.success("Preview updated!")
 
     with col_right:
-        # Calculate end_ens for plot
-        end_ens = n_ensembles - trim_end if trim_end > 0 else n_ensembles
-        plot_trim_ends(start_ens=trim_start, end_ens=end_ens, ens_range=int(ens_range))
+        plot_trim_ends(
+            start_ens=int(trim_start_ens),
+            end_ens=int(trim_end_ens) + 1,
+            ens_range=int(ens_range),
+        )
 
     if st.session_state.profile_preview_run:
         display_mask = st.session_state.preview_profile_proc.dataset["mask"].values
-        plot_heatmap(display_mask, "Revised Mask", colorscale="greys")
+        plot_heatmap(
+            display_mask, "Revised Mask", colorscale=[[0, "white"], [1, "red"]]
+        )
 # =============================================================================
 # TAB 2: SIDE LOBE CONTAMINATION
 # =============================================================================
@@ -587,15 +557,9 @@ with tab2:
             runner = preview_profile_proc.get_profile_operation_runner()
 
             # Apply trim first if set
-            if st.session_state.trim_start > 0 or st.session_state.trim_end > 0:
-                runner.trim_ensembles(
-                    start=st.session_state.trim_start
-                    if st.session_state.trim_start > 0
-                    else None,
-                    end=st.session_state.trim_end
-                    if st.session_state.trim_end > 0
-                    else None,
-                )
+            start_count, end_count = _trim_to_counts()
+            if start_count is not None or end_count is not None:
+                runner.trim_ensembles(start=start_count, end=end_count)
 
             # Apply side lobe cutting
             if apply_side_lobe:
@@ -781,15 +745,9 @@ with tab3:
             runner = preview_profile_proc.get_profile_operation_runner()
 
             # Apply trim first if set
-            if st.session_state.trim_start > 0 or st.session_state.trim_end > 0:
-                runner.trim_ensembles(
-                    start=st.session_state.trim_start
-                    if st.session_state.trim_start > 0
-                    else None,
-                    end=st.session_state.trim_end
-                    if st.session_state.trim_end > 0
-                    else None,
-                )
+            start_count, end_count = _trim_to_counts()
+            if start_count is not None or end_count is not None:
+                runner.trim_ensembles(start=start_count, end=end_count)
 
             # Apply side lobe if enabled
             if st.session_state.apply_side_lobe:
@@ -956,22 +914,10 @@ with tab4:
                 runner = preview_profile_proc.get_profile_operation_runner()
 
                 # Apply trim first if set
-                trim_start = st.session_state.trim_start
-                trim_end = st.session_state.trim_end
-                trimends = None
-                n_ens = ds.sizes.get("time", ds.sizes.get("ensemble", 100))
-                if trim_start > 0 or trim_end > 0:
-                    runner.trim_ensembles(
-                        start=trim_start if trim_start > 0 else None,
-                        end=trim_end if trim_end > 0 else None,
-                    )
-                    trimends = (trim_start, trim_end)
-                    end_idx = n_ens - trim_end if trim_end > 0 else n_ens
-                    start_idx = trim_start if trim_start > 0 else 0
-                    trimends = (
-                        start_idx,
-                        end_idx,
-                    )
+                start_count, end_count = _trim_to_counts()
+                trimends = _trim_trimends()
+                if start_count is not None or end_count is not None:
+                    runner.trim_ensembles(start=start_count, end=end_count)
 
                 # Apply side lobe if enabled
                 if st.session_state.apply_side_lobe:
@@ -1060,18 +1006,19 @@ with tab5:
 
         # Summary of operations to apply
         st.write("**Operations to apply:**")
+        n_ens_total = get_total_ensembles()
         summary_data = [
             [
-                "Trim Start",
-                str(st.session_state.trim_start)
-                if st.session_state.trim_start > 0
-                else "None",
+                "First Valid Ensemble",
+                str(st.session_state.trim_start_ens)
+                if st.session_state.trim_start_ens > 0
+                else "0 (no trim)",
             ],
             [
-                "Trim End",
-                str(st.session_state.trim_end)
-                if st.session_state.trim_end > 0
-                else "None",
+                "Last Valid Ensemble",
+                str(st.session_state.trim_end_ens)
+                if st.session_state.trim_end_ens < n_ens_total - 1
+                else f"{n_ens_total - 1} (no trim)",
             ],
             ["Side Lobe Cut", "True" if st.session_state.apply_side_lobe else "False"],
             ["Manual Regions", str(len(st.session_state.cut_regions))],
@@ -1088,20 +1035,10 @@ with tab5:
 
             try:
                 # Apply trim
-                trim_start = st.session_state.trim_start
-                trim_end = st.session_state.trim_end
-                trimends = None
-                n_ens = ds.sizes.get("time", ds.sizes.get("ensemble", 100))
-                if trim_start > 0 or trim_end > 0:
-                    runner.trim_ensembles(
-                        start=trim_start if trim_start > 0 else None,
-                        end=trim_end if trim_end > 0 else None,
-                    )
-                    start_idx = trim_start if trim_start > 0 else 0
-                    end_idx = n_ens - trim_end if trim_end > 0 else n_ens
-                    trimends = (start_idx, end_idx)
-
-                st.write("Trim Ensembles Complete")
+                start_count, end_count = _trim_to_counts()
+                trimends = _trim_trimends()
+                if start_count is not None or end_count is not None:
+                    runner.trim_ensembles(start=start_count, end=end_count)
 
                 # Apply side lobe
                 if st.session_state.apply_side_lobe:
@@ -1111,7 +1048,6 @@ with tab5:
                         extra_cells=st.session_state.extra_cells,
                     )
 
-                st.write("Side Lobe Complete")
                 # Apply manual cuts
                 for region in st.session_state.cut_regions:
                     runner.cut_bins_manual(
@@ -1121,11 +1057,6 @@ with tab5:
                         max_ensemble=region["max_ensemble"],
                     )
 
-                st.write("Cut Region Complete")
-                st.write(st.session_state.regrid_method)
-                st.write(st.session_state.end_cell_option)
-                st.write(trimends)
-                st.write(st.session_state.beam_direction.lower())
                 # Apply regrid (must be last)
                 if st.session_state.apply_regrid:
                     runner.regrid(
@@ -1206,8 +1137,8 @@ with tab5:
             st.session_state.profile_applied = False
             st.session_state.profile_preview_run = False
             st.session_state.profile_preview_stats = None
-            st.session_state.trim_start = 0
-            st.session_state.trim_end = 0
+            st.session_state.trim_start_ens = 0
+            st.session_state.trim_end_ens = max(0, get_total_ensembles() - 1)
             st.session_state.apply_side_lobe = False
             st.session_state.cut_regions = []
             st.session_state.apply_regrid = False
@@ -1255,8 +1186,8 @@ with st.sidebar:
     st.write("---")
 
     st.write("**Profile Operations Status:**")
-    st.write(f"- Trim Start: `{st.session_state.trim_start}`")
-    st.write(f"- Trim End: `{st.session_state.trim_end}`")
+    st.write(f"- First Valid: `{st.session_state.trim_start_ens}`")
+    st.write(f"- Last Valid: `{st.session_state.trim_end_ens}`")
     st.write(f"- Side Lobe: {'✅' if st.session_state.apply_side_lobe else '❌'}")
     st.write(f"- Manual Regions: `{len(st.session_state.cut_regions)}`")
     st.write(f"- Regrid: {'✅' if st.session_state.apply_regrid else '❌'}")

--- a/src/pyadps/pages/06_Profile_Operations.py
+++ b/src/pyadps/pages/06_Profile_Operations.py
@@ -1091,12 +1091,17 @@ with tab5:
                 trim_start = st.session_state.trim_start
                 trim_end = st.session_state.trim_end
                 trimends = None
+                n_ens = ds.sizes.get("time", ds.sizes.get("ensemble", 100))
                 if trim_start > 0 or trim_end > 0:
                     runner.trim_ensembles(
                         start=trim_start if trim_start > 0 else None,
                         end=trim_end if trim_end > 0 else None,
                     )
-                    trimends = (trim_start, trim_end)
+                    start_idx = trim_start if trim_start > 0 else 0
+                    end_idx = n_ens - trim_end if trim_end > 0 else n_ens
+                    trimends = (start_idx, end_idx)
+
+                st.write("Trim Ensembles Complete")
 
                 # Apply side lobe
                 if st.session_state.apply_side_lobe:
@@ -1106,6 +1111,7 @@ with tab5:
                         extra_cells=st.session_state.extra_cells,
                     )
 
+                st.write("Side Lobe Complete")
                 # Apply manual cuts
                 for region in st.session_state.cut_regions:
                     runner.cut_bins_manual(
@@ -1115,6 +1121,11 @@ with tab5:
                         max_ensemble=region["max_ensemble"],
                     )
 
+                st.write("Cut Region Complete")
+                st.write(st.session_state.regrid_method)
+                st.write(st.session_state.end_cell_option)
+                st.write(trimends)
+                st.write(st.session_state.beam_direction.lower())
                 # Apply regrid (must be last)
                 if st.session_state.apply_regrid:
                     runner.regrid(

--- a/src/pyadps/processing/config.py
+++ b/src/pyadps/processing/config.py
@@ -220,6 +220,8 @@ class ProcessingConfig:
     isRegridCheck_PT: bool = False
     regrid_cell_size_PT: float = 1.0
     regrid_method_PT: str = "nearest"  # interpolation method passed to runner.regrid()
+    regrid_end_cell_option_PT: str = "cell"  # "cell", "surface", or "manual"
+    regrid_boundary_limit_PT: float = 0.0  # used when end_cell_option="manual"
     beam_direction_PT: str = "up"
 
     # ========================
@@ -453,6 +455,12 @@ class ProcessingConfig:
             kwargs["regrid_method_PT"] = config.get(
                 "ProfileTest", "regrid_method", fallback="nearest"
             )
+            kwargs["regrid_end_cell_option_PT"] = config.get(
+                "ProfileTest", "regrid_end_cell_option", fallback="cell"
+            )
+            kwargs["regrid_boundary_limit_PT"] = config.getfloat(
+                "ProfileTest", "regrid_boundary_limit", fallback=0.0
+            )
             kwargs["beam_direction_PT"] = config.get(
                 "ProfileTest", "beam_direction", fallback="up"
             )
@@ -640,6 +648,8 @@ class ProcessingConfig:
             "regrid": str(self.isRegridCheck_PT),
             "regrid_cell_size": str(self.regrid_cell_size_PT),
             "regrid_method": self.regrid_method_PT,
+            "regrid_end_cell_option": self.regrid_end_cell_option_PT,
+            "regrid_boundary_limit": str(self.regrid_boundary_limit_PT),
             "beam_direction": self.beam_direction_PT,
         }
 

--- a/src/pyadps/processing/core.py
+++ b/src/pyadps/processing/core.py
@@ -696,6 +696,8 @@ class ProcessedDataset:
         # Regrid
         regrid: bool = False,
         regrid_method: str = "nearest",
+        regrid_end_cell_option: str = "cell",
+        regrid_boundary_limit: float = 0.0,
     ) -> ProcessedDataset:
         """
         Apply profile operations (STEP 4 of 6).
@@ -703,7 +705,7 @@ class ProcessedDataset:
         Modifies profile structure through ensemble trimming, bin cutting,
         and regridding. Uses ProfileOperationRunner for processing.
 
-        âš ï¸ IMPORTANT: Profile operations should be applied AFTER QC checks
+        IMPORTANT: Profile operations should be applied AFTER QC checks
         because regridding changes the cell structure, invalidating cell-based masks.
 
         Parameters
@@ -728,7 +730,12 @@ class ProcessedDataset:
         regrid : bool, default False
             Enable regridding to regular depth grid.
         regrid_method : str, default 'nearest'
-            Interpolation method ('linear', 'nearest').
+            Interpolation method ('nearest', 'linear', 'cubic').
+        regrid_end_cell_option : str, default 'cell'
+            Depth extent of the regridded grid: 'cell' (to last valid cell),
+            'surface' (to water surface), or 'manual' (use regrid_boundary_limit).
+        regrid_boundary_limit : float, default 0.0
+            Depth boundary in metres when regrid_end_cell_option='manual'.
 
         Returns
         -------
@@ -806,8 +813,21 @@ class ProcessedDataset:
 
         # Regrid (must be last)
         if regrid:
+            # Derive trimends from trim_start/trim_end so the depth grid
+            # calculation excludes deployment/recovery periods.
+            regrid_trimends = None
+            if trim_start is not None or trim_end is not None:
+                n_ens = self.dataset.sizes.get("time", self.dataset.sizes.get("ensemble", 0))
+                start_idx = trim_start if trim_start is not None else 0
+                end_idx = n_ens - trim_end if trim_end is not None else n_ens
+                regrid_trimends = (start_idx, end_idx)
+
             runner.regrid(
                 method=regrid_method,
+                end_cell_option=regrid_end_cell_option,
+                boundary_limit=regrid_boundary_limit,
+                trimends=regrid_trimends,
+                orientation=beam_direction,
             )
 
         # Commit changes
@@ -861,6 +881,8 @@ class ProcessedDataset:
         # Regrid
         self.config.isRegridCheck_PT = regrid
         self.config.regrid_method_PT = regrid_method
+        self.config.regrid_end_cell_option_PT = regrid_end_cell_option
+        self.config.regrid_boundary_limit_PT = regrid_boundary_limit
         # ----------------------------------------------------------------------
 
         return self
@@ -1376,6 +1398,8 @@ class ProcessedDataset:
             if config.isRegridCheck_PT:
                 profile_kwargs["regrid"] = True
                 profile_kwargs["regrid_method"] = config.regrid_method_PT
+                profile_kwargs["regrid_end_cell_option"] = config.regrid_end_cell_option_PT
+                profile_kwargs["regrid_boundary_limit"] = config.regrid_boundary_limit_PT
                 profile_kwargs["beam_direction"] = config.beam_direction_PT
 
             if profile_kwargs:

--- a/src/pyadps/processing/core.py
+++ b/src/pyadps/processing/core.py
@@ -37,6 +37,12 @@ from typing import Any, Dict, List, Optional, Union
 import numpy as np
 import xarray as xr
 
+try:
+    from importlib.metadata import version as _get_version
+    _PYADPS_VERSION = _get_version("pyadps")
+except Exception:  # pragma: no cover
+    _PYADPS_VERSION = "0.0.0.dev0"  # pragma: no cover
+
 from .utility import (
     create_default_mask,
     QCCheckStats,
@@ -1194,7 +1200,7 @@ class ProcessedDataset:
 
         # Add processing metadata
         processing_time = datetime.now(timezone.utc)
-        ds_out.attrs["pyadps_version"] = "1.1.0"
+        ds_out.attrs["pyadps_version"] = _PYADPS_VERSION
         ds_out.attrs["processed_at"] = processing_time.isoformat()
         ds_out.attrs["processing_log"] = str(self.processing_log)
         ds_out.attrs["total_cells"] = self._total_cells
@@ -2186,7 +2192,7 @@ class ProcessedDataset:
             ds_out.attrs = {
                 "title": "ADCP Velocity Components",
                 "institution": ds_final.attrs.get("institution", ""),
-                "source": "pyadps v1.1.0",
+                "source": f"pyadps v{_PYADPS_VERSION}",
                 "history": f"Created {datetime.now(timezone.utc).isoformat()}",
                 "references": "pyadps ADCP processing package",
                 "Conventions": "CF-1.8",
@@ -2214,7 +2220,7 @@ class ProcessedDataset:
                     ds_out.attrs[attr] = ds_final.attrs[attr]
         else:
             ds_out.attrs = {
-                "source": "pyadps v1.1.0",
+                "source": f"pyadps v{_PYADPS_VERSION}",
                 "Conventions": "CF-1.8",
             }
 

--- a/src/pyadps/processing/profile_operation.py
+++ b/src/pyadps/processing/profile_operation.py
@@ -1122,7 +1122,7 @@ class ProfileOperationRunner:
     and VelocityCheckRunner style. Coordinates ensemble trimming, bin cutting,
     and regridding operations with comprehensive statistics tracking.
 
-    âš ï¸ IMPORTANT SEQUENCING:
+    IMPORTANT SEQUENCING:
     1. Quality control checks MUST happen BEFORE regridding
     2. Regridding INVALIDATES cell-based masks
     3. Use this class AFTER all QC steps are complete

--- a/tests/pages/test_06_Profile_Operations.py
+++ b/tests/pages/test_06_Profile_Operations.py
@@ -40,7 +40,7 @@ TestPageFunctionsDirectly    all helper function branches via importlib:
                                get_bin1_distance, get_beam_angle,
                                get_beam_direction (all 5 branches),
                                status_color_map, plot_heatmap 3-D + mask,
-                               plot_mask_comparison 2-D/3-D branches
+                               _trim_has_effect/_trim_to_counts/_trim_trimends
 
 Run with:
     pytest test_06_Profile_Operations.py -v
@@ -53,6 +53,7 @@ import importlib.util
 import sys
 import types
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -350,10 +351,10 @@ class TestPageLoads:
         assert "Enable Side Lobe Cutting" in labels
         assert "Enable Regridding" in labels
 
-    def test_trim_sliders_present(self, loaded_at):
-        labels = [s.label for s in loaded_at.slider]
-        assert any("start" in l.lower() for l in labels)
-        assert any("end" in l.lower() for l in labels)
+    def test_trim_number_inputs_present(self, loaded_at):
+        labels = [n.label for n in loaded_at.number_input]
+        assert any("First valid" in l for l in labels)
+        assert any("Last valid" in l for l in labels)
 
     def test_preview_buttons_present(self, loaded_at):
         labels = [b.label for b in loaded_at.button]
@@ -395,8 +396,8 @@ class TestSessionStateInit:
         "profile_initialized",
         "profile_applied",
         "profile_preview_run",
-        "trim_start",
-        "trim_end",
+        "trim_start_ens",
+        "trim_end_ens",
         "apply_side_lobe",
         "water_depth",
         "extra_cells",
@@ -428,11 +429,12 @@ class TestSessionStateInit:
     def test_profile_preview_run_false(self, loaded_at):
         assert loaded_at.session_state["profile_preview_run"] is False
 
-    def test_trim_start_zero(self, loaded_at):
-        assert loaded_at.session_state["trim_start"] == 0
+    def test_trim_start_ens_zero(self, loaded_at):
+        assert loaded_at.session_state["trim_start_ens"] == 0
 
-    def test_trim_end_zero(self, loaded_at):
-        assert loaded_at.session_state["trim_end"] == 0
+    def test_trim_end_ens_default(self, loaded_at):
+        # default = n_ens - 1 = 99 for a 100-ensemble dataset
+        assert loaded_at.session_state["trim_end_ens"] == 99
 
     def test_apply_side_lobe_false(self, loaded_at):
         assert loaded_at.session_state["apply_side_lobe"] is False
@@ -529,21 +531,21 @@ class TestSidebarStatus:
 
 
 class TestTab1TrimEnds:
-    """Trim sliders, Preview Trim button, and post-preview mask display."""
+    """Trim number_inputs, Preview Trim button, and post-preview mask display."""
 
-    def test_trim_start_slider_default_zero(self, loaded_at):
-        sl = [s for s in loaded_at.slider if "start" in s.label.lower()][0]
-        assert sl.value == 0
+    def test_trim_start_ens_input_default_zero(self, loaded_at):
+        ni = [n for n in loaded_at.number_input if "First valid" in n.label][0]
+        assert ni.value == 0
 
-    def test_trim_end_slider_default_zero(self, loaded_at):
-        sl = [s for s in loaded_at.slider if "end" in s.label.lower()][0]
-        assert sl.value == 0
+    def test_trim_end_ens_input_default_last(self, loaded_at):
+        ni = [n for n in loaded_at.number_input if "Last valid" in n.label][0]
+        assert ni.value == 99  # n_ens - 1
 
     def test_display_range_input_present(self, loaded_at):
         assert any("Display range" in n.label for n in loaded_at.number_input)
 
     def test_preview_trim_zero_trim_sets_flag(self, proc):
-        """Preview with zero trim still sets profile_preview_run=True."""
+        """Preview with default (no-op) trim still sets profile_preview_run=True."""
         at = _make_loaded_at(proc)
         [b for b in at.button if "Preview Trim" in b.label][0].click().run()
         assert not at.exception
@@ -551,8 +553,8 @@ class TestTab1TrimEnds:
 
     def test_preview_trim_with_nonzero_start(self, proc):
         at = _make_loaded_at(proc)
-        sl = [s for s in at.slider if "start" in s.label.lower()][0]
-        sl.set_value(5).run()
+        ni = [n for n in at.number_input if "First valid" in n.label][0]
+        ni.set_value(5).run()
         [b for b in at.button if "Preview Trim" in b.label][0].click().run()
         assert not at.exception
         success = " ".join(s.value for s in at.success)
@@ -560,21 +562,95 @@ class TestTab1TrimEnds:
 
     def test_preview_trim_calls_runner(self, proc):
         at = _make_loaded_at(proc)
-        sl = [s for s in at.slider if "start" in s.label.lower()][0]
-        sl.set_value(3).run()
+        ni = [n for n in at.number_input if "First valid" in n.label][0]
+        ni.set_value(3).run()
         [b for b in at.button if "Preview Trim" in b.label][0].click().run()
         proc.get_profile_operation_runner.assert_called()
 
-    def test_trim_start_updates_session_state(self, proc):
+    def test_trim_start_ens_updates_session_state(self, proc):
         at = _make_loaded_at(proc)
-        sl = [s for s in at.slider if "start" in s.label.lower()][0]
-        sl.set_value(7).run()
-        assert at.session_state["trim_start"] == 7
+        ni = [n for n in at.number_input if "First valid" in n.label][0]
+        ni.set_value(7).run()
+        assert at.session_state["trim_start_ens"] == 7
+
+    def test_trim_end_ens_updates_session_state(self, proc):
+        at = _make_loaded_at(proc)
+        ni = [n for n in at.number_input if "Last valid" in n.label][0]
+        ni.set_value(90).run()
+        assert at.session_state["trim_end_ens"] == 90
 
     def test_mask_heatmap_displayed_after_preview(self, proc):
-        """Lines 513-515: profile_preview_run=True shows revised mask heatmap."""
+        """profile_preview_run=True shows revised mask heatmap."""
         at = _make_loaded_at(proc, extra_ss={"profile_preview_run": True})
         assert not at.exception
+
+
+# ===========================================================================
+# 6b. Trim helper functions
+# ===========================================================================
+
+
+class TestTrimHelpers:
+    """Direct tests for _trim_has_effect, _trim_to_counts, _trim_trimends."""
+
+    def _ss(self, start, end):
+        return SimpleNamespace(trim_start_ens=start, trim_end_ens=end)
+
+    def test_has_effect_false_when_full_range(self, page_module):
+        page_module.ds = _make_ds(n_ens=100)
+        with patch.object(page_module.st, "session_state", self._ss(0, 99)):
+            assert page_module._trim_has_effect() is False
+
+    def test_has_effect_true_when_start_nonzero(self, page_module):
+        page_module.ds = _make_ds(n_ens=100)
+        with patch.object(page_module.st, "session_state", self._ss(5, 99)):
+            assert page_module._trim_has_effect() is True
+
+    def test_has_effect_true_when_end_reduced(self, page_module):
+        page_module.ds = _make_ds(n_ens=100)
+        with patch.object(page_module.st, "session_state", self._ss(0, 94)):
+            assert page_module._trim_has_effect() is True
+
+    def test_to_counts_no_trim(self, page_module):
+        page_module.ds = _make_ds(n_ens=100)
+        with patch.object(page_module.st, "session_state", self._ss(0, 99)):
+            start_count, end_count = page_module._trim_to_counts()
+        assert start_count is None
+        assert end_count is None
+
+    def test_to_counts_start_only(self, page_module):
+        page_module.ds = _make_ds(n_ens=100)
+        with patch.object(page_module.st, "session_state", self._ss(5, 99)):
+            start_count, end_count = page_module._trim_to_counts()
+        assert start_count == 5
+        assert end_count is None
+
+    def test_to_counts_end_only(self, page_module):
+        # trim_end_ens=94 means last valid is 94; ensembles 95-99 trimmed → end_count=5
+        page_module.ds = _make_ds(n_ens=100)
+        with patch.object(page_module.st, "session_state", self._ss(0, 94)):
+            start_count, end_count = page_module._trim_to_counts()
+        assert start_count is None
+        assert end_count == 5  # 100 - 1 - 94
+
+    def test_to_counts_both(self, page_module):
+        page_module.ds = _make_ds(n_ens=100)
+        with patch.object(page_module.st, "session_state", self._ss(10, 89)):
+            start_count, end_count = page_module._trim_to_counts()
+        assert start_count == 10
+        assert end_count == 10  # 100 - 1 - 89
+
+    def test_trimends_none_when_no_effect(self, page_module):
+        page_module.ds = _make_ds(n_ens=100)
+        with patch.object(page_module.st, "session_state", self._ss(0, 99)):
+            result = page_module._trim_trimends()
+        assert result is None
+
+    def test_trimends_returns_tuple(self, page_module):
+        page_module.ds = _make_ds(n_ens=100)
+        with patch.object(page_module.st, "session_state", self._ss(10, 89)):
+            result = page_module._trim_trimends()
+        assert result == (10, 90)  # (trim_start_ens, trim_end_ens + 1)
 
 
 # ===========================================================================
@@ -611,7 +687,7 @@ class TestTab2SideLobe:
             "profile_initialized": True,
             "profile_applied": False,
             "profile_preview_run": False,
-            "trim_start": 0, "trim_end": 0,
+            "trim_start_ens": 0, "trim_end_ens": 99,
             "apply_side_lobe": True,
             "water_depth": None,
             "extra_cells": 1,
@@ -715,7 +791,7 @@ class TestTab3ManualCut:
             "profile_initialized": True,
             "profile_applied": False,
             "profile_preview_run": False,
-            "trim_start": 0, "trim_end": 0,
+            "trim_start_ens": 0, "trim_end_ens": 99,
             "apply_side_lobe": False,
             "water_depth": None,
             "extra_cells": 1,
@@ -738,7 +814,7 @@ class TestTab3ManualCut:
             "profile_initialized": True,
             "profile_applied": False,
             "profile_preview_run": False,
-            "trim_start": 0, "trim_end": 0,
+            "trim_start_ens": 0, "trim_end_ens": 99,
             "apply_side_lobe": False,
             "water_depth": None,
             "extra_cells": 1,
@@ -763,7 +839,7 @@ class TestTab3ManualCut:
             "profile_initialized": True,
             "profile_applied": False,
             "profile_preview_run": False,
-            "trim_start": 0, "trim_end": 0,
+            "trim_start_ens": 0, "trim_end_ens": 99,
             "apply_side_lobe": False,
             "water_depth": None,
             "extra_cells": 1,
@@ -821,7 +897,7 @@ class TestTab4Regrid:
             "profile_initialized": True,
             "profile_applied": False,
             "profile_preview_run": False,
-            "trim_start": 0, "trim_end": 0,
+            "trim_start_ens": 0, "trim_end_ens": 99,
             "apply_side_lobe": False,
             "water_depth": None,
             "extra_cells": 1,
@@ -919,16 +995,14 @@ class TestTab5ResetButton:
         assert at.session_state["profile_applied"] is False
 
     def test_clears_trim_start(self, proc):
-        # Reset calls st.rerun(); after the rerun the slider widget
-        # (key="trim_start_slider") rebinds trim_start from its own widget
-        # state, so we cannot assert trim_start==0 in session state after
-        # the rerun.  We verify proc.reset() was called (the real side-effect)
-        # and that the page re-renders cleanly.
+        # Reset calls st.rerun(); after the rerun the number_input widget
+        # (key="trim_start_ens_input") rebinds trim_start_ens from widget state.
+        # We verify proc.reset() was called and the page re-renders cleanly.
         at = _make_loaded_at(proc, extra_ss={
             "profile_initialized": True,
             "profile_applied": False,
             "profile_preview_run": False,
-            "trim_start": 5, "trim_end": 0,
+            "trim_start_ens": 5, "trim_end_ens": 99,
             "apply_side_lobe": False,
             "water_depth": None,
             "extra_cells": 1,
@@ -950,7 +1024,7 @@ class TestTab5ResetButton:
             "profile_initialized": True,
             "profile_applied": False,
             "profile_preview_run": False,
-            "trim_start": 0, "trim_end": 0,
+            "trim_start_ens": 0, "trim_end_ens": 99,
             "apply_side_lobe": False,
             "water_depth": None,
             "extra_cells": 1,
@@ -968,14 +1042,12 @@ class TestTab5ResetButton:
         assert at.session_state["cut_regions"] == []
 
     def test_clears_apply_side_lobe(self, proc):
-        # Reset calls st.rerun(); the checkbox widget (key="apply_side_lobe_cb")
-        # rebinds apply_side_lobe after the rerun, so we assert on proc.reset()
-        # and clean re-render rather than the session state value.
+        # Reset calls st.rerun(); checkbox widget rebinds after rerun.
         at = _make_loaded_at(proc, extra_ss={
             "profile_initialized": True,
             "profile_applied": False,
             "profile_preview_run": False,
-            "trim_start": 0, "trim_end": 0,
+            "trim_start_ens": 0, "trim_end_ens": 99,
             "apply_side_lobe": True,
             "water_depth": None,
             "extra_cells": 1,
@@ -1005,8 +1077,8 @@ class TestAppliedBanner:
         return {
             "profile_applied": True,
             "profile_initialized": True,
-            "trim_start": 0,
-            "trim_end": 0,
+            "trim_start_ens": 0,
+            "trim_end_ens": 99,
             "apply_side_lobe": False,
             "water_depth": None,
             "extra_cells": 1,
@@ -1040,10 +1112,11 @@ class TestSaveWithOperations:
     """Verify each operation type is forwarded to the runner."""
 
     def test_save_with_trim(self, proc):
+        # trim_start_ens=5 → start_count=5; trim_end_ens=96 → end_count=3
         at = _make_loaded_at(proc, extra_ss={
             "profile_initialized": True, "profile_applied": False,
             "profile_preview_run": False, "profile_preview_stats": None,
-            "trim_start": 5, "trim_end": 3,
+            "trim_start_ens": 5, "trim_end_ens": 96,
             "apply_side_lobe": False, "water_depth": None, "extra_cells": 1,
             "cut_regions": [], "apply_regrid": False,
             "regrid_method": "nearest", "end_cell_option": "cell", "boundary_limit": 0.0,
@@ -1057,7 +1130,7 @@ class TestSaveWithOperations:
         at = _make_loaded_at(proc, extra_ss={
             "profile_initialized": True, "profile_applied": False,
             "profile_preview_run": False, "profile_preview_stats": None,
-            "trim_start": 0, "trim_end": 0,
+            "trim_start_ens": 0, "trim_end_ens": 99,
             "apply_side_lobe": True, "water_depth": None, "extra_cells": 1,
             "cut_regions": [], "apply_regrid": False,
             "regrid_method": "nearest", "end_cell_option": "cell", "boundary_limit": 0.0,
@@ -1072,7 +1145,7 @@ class TestSaveWithOperations:
         at = _make_loaded_at(proc, extra_ss={
             "profile_initialized": True, "profile_applied": False,
             "profile_preview_run": False, "profile_preview_stats": None,
-            "trim_start": 0, "trim_end": 0,
+            "trim_start_ens": 0, "trim_end_ens": 99,
             "apply_side_lobe": False, "water_depth": None, "extra_cells": 1,
             "cut_regions": [region], "apply_regrid": False,
             "regrid_method": "nearest", "end_cell_option": "cell", "boundary_limit": 0.0,
@@ -1086,7 +1159,7 @@ class TestSaveWithOperations:
         at = _make_loaded_at(proc, extra_ss={
             "profile_initialized": True, "profile_applied": False,
             "profile_preview_run": False, "profile_preview_stats": None,
-            "trim_start": 0, "trim_end": 0,
+            "trim_start_ens": 0, "trim_end_ens": 99,
             "apply_side_lobe": False, "water_depth": None, "extra_cells": 1,
             "cut_regions": [], "apply_regrid": True,
             "regrid_method": "nearest", "end_cell_option": "cell", "boundary_limit": 0.0,
@@ -1581,25 +1654,6 @@ class TestPageFunctionsDirectly:
                 mask_data=np.zeros((20, 100), dtype=np.int8),
             )
 
-    # ---- plot_mask_comparison ----------------------------------------
-
-    def test_plot_mask_comparison_3d_masks_lines296_302(self, page_module, ds):
-        """Lines 296-297, 301-302: both masks 3-D → first-beam slices used."""
-        page_module.ds = ds
-        with patch("streamlit.plotly_chart"):
-            page_module.plot_mask_comparison(
-                np.zeros((4, 20, 100), dtype=np.int8),
-                np.ones((4, 20, 100), dtype=np.int8),
-            )
-
-    def test_plot_mask_comparison_2d_masks_lines298_304(self, page_module, ds):
-        """Lines 298-299, 303-304: both masks 2-D → used directly."""
-        page_module.ds = ds
-        with patch("streamlit.plotly_chart"):
-            page_module.plot_mask_comparison(
-                np.zeros((20, 100), dtype=np.int8),
-                np.ones((20, 100), dtype=np.int8),
-            )
 
 
 
@@ -1612,15 +1666,15 @@ class TestPageFunctionsDirectly:
 class TestRemainingCoverage:
     """Targeted AppTest and direct-function tests for remaining gaps."""
 
-    def _full_ss(self, *, trim_start=0, trim_end=0, apply_side_lobe=False,
+    def _full_ss(self, *, trim_start_ens=0, trim_end_ens=99, apply_side_lobe=False,
                  cut_regions=None, apply_regrid=False, beam_direction="Up",
                  water_depth=None):
         return {
             "profile_initialized": True,
             "profile_applied": False,
             "profile_preview_run": False,
-            "trim_start": trim_start,
-            "trim_end": trim_end,
+            "trim_start_ens": trim_start_ens,
+            "trim_end_ens": trim_end_ens,
             "apply_side_lobe": apply_side_lobe,
             "water_depth": water_depth,
             "extra_cells": 1,
@@ -1641,9 +1695,9 @@ class TestRemainingCoverage:
         with patch("streamlit.plotly_chart"):
             page_module.plot_trim_ends(start_ens=0, end_ens=None, ens_range=20)
 
-    # 591: Preview Side Lobe with trim_start > 0
+    # 591: Preview Side Lobe with trim_start_ens > 0
     def test_preview_sidelobe_with_trim_line591(self, proc):
-        at = _make_loaded_at(proc, extra_ss=self._full_ss(trim_start=5))
+        at = _make_loaded_at(proc, extra_ss=self._full_ss(trim_start_ens=5))
         [b for b in at.button if "Preview Side Lobe" in b.label][0].click().run()
         assert not at.exception
 
@@ -1661,16 +1715,16 @@ class TestRemainingCoverage:
         at.run()
         assert not at.exception
 
-    # 759-761: Preview Trim success message + profile_preview_run=True
-    def test_preview_trim_success_message_lines759_761(self, proc):
-        at = _make_loaded_at(proc, extra_ss=self._full_ss(trim_start=5))
+    # Preview Trim success message + profile_preview_run=True
+    def test_preview_trim_success_message(self, proc):
+        at = _make_loaded_at(proc, extra_ss=self._full_ss(trim_start_ens=5))
         [b for b in at.button if "Preview Trim" in b.label][0].click().run()
         assert not at.exception
         assert at.session_state["profile_preview_run"] is True
 
-    # 785: Preview Manual Cuts with trim set
-    def test_preview_manual_with_trim_line785(self, proc):
-        at = _make_loaded_at(proc, extra_ss=self._full_ss(trim_start=5))
+    # Preview Manual Cuts with trim set
+    def test_preview_manual_with_trim(self, proc):
+        at = _make_loaded_at(proc, extra_ss=self._full_ss(trim_start_ens=5))
         [b for b in at.button if "Preview Manual" in b.label][0].click().run()
         assert not at.exception
 
@@ -1753,7 +1807,7 @@ class TestRemainingCoverage:
         at = _make_loaded_at(proc_down, extra_ss={
             "profile_initialized": True, "profile_applied": False,
             "profile_preview_run": False, "profile_preview_stats": None,
-            "trim_start": 0, "trim_end": 0,
+            "trim_start_ens": 0, "trim_end_ens": 99,
             "apply_side_lobe": False, "water_depth": 0.0, "extra_cells": 1,
             "cut_regions": [], "apply_regrid": True,
             "regrid_method": "nearest", "end_cell_option": "manual",
@@ -1761,10 +1815,10 @@ class TestRemainingCoverage:
         })
         assert not at.exception
 
-    # 964-971: Preview Regrid with trim set (trimends path)
-    def test_preview_regrid_with_trim_lines964_971(self, proc):
+    # Preview Regrid with trim set (trimends path)
+    def test_preview_regrid_with_trim(self, proc):
         at = _make_loaded_at(proc, extra_ss=self._full_ss(
-            trim_start=5, apply_regrid=True))
+            trim_start_ens=5, apply_regrid=True))
         [b for b in at.button if "Preview Regrid" in b.label][0].click().run()
         assert not at.exception
 
@@ -1833,12 +1887,12 @@ class TestRemainingCoverage:
         at = _make_loaded_at(proc_2b, extra_ss={
             "profile_initialized": True, "profile_applied": False,
             "profile_preview_run": False, "profile_preview_stats": None,
-            "trim_start": 0, "trim_end": 0,
+            "trim_start_ens": 0, "trim_end_ens": 99,
             "apply_side_lobe": False, "water_depth": None, "extra_cells": 1,
             "cut_regions": [], "apply_regrid": False,
             "regrid_method": "nearest", "end_cell_option": "cell",
             "boundary_limit": 0.0, "beam_direction": "Up",
-            "profile_beam": 3,  # > velocity.shape[0]=2 → line 1028
+            "profile_beam": 3,  # > velocity.shape[0]=2 → fallback beam index
         })
         assert not at.exception
 

--- a/tests/processing/test_core.py
+++ b/tests/processing/test_core.py
@@ -3903,6 +3903,29 @@ class TestApplyConfigProfileForwarding:
         )
         assert kw["beam_direction"] == "up"
 
+    def test_regrid_end_cell_option_forwarded(self, sample_dataset):
+        kw = self._call_kwargs(
+            sample_dataset,
+            _all_disabled_config(
+                isProfileTest=True,
+                isRegridCheck_PT=True,
+                regrid_end_cell_option_PT="surface",
+            ),
+        )
+        assert kw["regrid_end_cell_option"] == "surface"
+
+    def test_regrid_boundary_limit_forwarded(self, sample_dataset):
+        kw = self._call_kwargs(
+            sample_dataset,
+            _all_disabled_config(
+                isProfileTest=True,
+                isRegridCheck_PT=True,
+                regrid_end_cell_option_PT="manual",
+                regrid_boundary_limit_PT=25.0,
+            ),
+        )
+        assert kw["regrid_boundary_limit"] == pytest.approx(25.0)
+
     # ---- empty-kwargs guard ----------------------------------------------
 
     def test_apply_profile_operation_not_called_when_kwargs_empty(self, sample_dataset):
@@ -4735,6 +4758,136 @@ class TestConfigTracking:
 
         assert proc.config.isRegridCheck_PT is True
         assert proc.config.regrid_method_PT == "nearest"
+
+    @patch(PROFILE_OPERATION_RUNNER)
+    def test_apply_profile_operation_records_regrid_end_cell_option(
+        self, mock_class, sample_dataset
+    ):
+        """apply_profile_operation records regrid_end_cell_option into config."""
+        mock_runner = MagicMock()
+        mock_runner.finalize.return_value = sample_dataset
+        mock_runner.get_pipeline_report.return_value = MagicMock()
+        mock_runner.statistics = []
+        mock_runner.modifications = []
+        mock_class.return_value = mock_runner
+
+        proc = ProcessedDataset(sample_dataset)
+        proc.apply_profile_operation(regrid=True, regrid_end_cell_option="surface")
+
+        assert proc.config.regrid_end_cell_option_PT == "surface"
+
+    @patch(PROFILE_OPERATION_RUNNER)
+    def test_apply_profile_operation_records_regrid_boundary_limit(
+        self, mock_class, sample_dataset
+    ):
+        """apply_profile_operation records regrid_boundary_limit into config."""
+        mock_runner = MagicMock()
+        mock_runner.finalize.return_value = sample_dataset
+        mock_runner.get_pipeline_report.return_value = MagicMock()
+        mock_runner.statistics = []
+        mock_runner.modifications = []
+        mock_class.return_value = mock_runner
+
+        proc = ProcessedDataset(sample_dataset)
+        proc.apply_profile_operation(
+            regrid=True, regrid_end_cell_option="manual", regrid_boundary_limit=30.0
+        )
+
+        assert proc.config.regrid_end_cell_option_PT == "manual"
+        assert proc.config.regrid_boundary_limit_PT == pytest.approx(30.0)
+
+    @patch(PROFILE_OPERATION_RUNNER)
+    def test_apply_profile_operation_regrid_passes_end_cell_option_to_runner(
+        self, mock_class, sample_dataset
+    ):
+        """runner.regrid() receives end_cell_option from apply_profile_operation."""
+        mock_runner = MagicMock()
+        mock_runner.finalize.return_value = sample_dataset
+        mock_runner.get_pipeline_report.return_value = MagicMock()
+        mock_runner.statistics = []
+        mock_runner.modifications = []
+        mock_class.return_value = mock_runner
+
+        proc = ProcessedDataset(sample_dataset)
+        proc.apply_profile_operation(regrid=True, regrid_end_cell_option="surface")
+
+        kw = mock_runner.regrid.call_args.kwargs
+        assert kw["end_cell_option"] == "surface"
+
+    @patch(PROFILE_OPERATION_RUNNER)
+    def test_apply_profile_operation_regrid_passes_boundary_limit_to_runner(
+        self, mock_class, sample_dataset
+    ):
+        """runner.regrid() receives boundary_limit from apply_profile_operation."""
+        mock_runner = MagicMock()
+        mock_runner.finalize.return_value = sample_dataset
+        mock_runner.get_pipeline_report.return_value = MagicMock()
+        mock_runner.statistics = []
+        mock_runner.modifications = []
+        mock_class.return_value = mock_runner
+
+        proc = ProcessedDataset(sample_dataset)
+        proc.apply_profile_operation(
+            regrid=True, regrid_end_cell_option="manual", regrid_boundary_limit=20.0
+        )
+
+        kw = mock_runner.regrid.call_args.kwargs
+        assert kw["boundary_limit"] == pytest.approx(20.0)
+
+    @patch(PROFILE_OPERATION_RUNNER)
+    def test_apply_profile_operation_regrid_passes_orientation_to_runner(
+        self, mock_class, sample_dataset
+    ):
+        """runner.regrid() receives beam_direction as orientation."""
+        mock_runner = MagicMock()
+        mock_runner.finalize.return_value = sample_dataset
+        mock_runner.get_pipeline_report.return_value = MagicMock()
+        mock_runner.statistics = []
+        mock_runner.modifications = []
+        mock_class.return_value = mock_runner
+
+        proc = ProcessedDataset(sample_dataset)
+        proc.apply_profile_operation(regrid=True, beam_direction="down")
+
+        kw = mock_runner.regrid.call_args.kwargs
+        assert kw["orientation"] == "down"
+
+    @patch(PROFILE_OPERATION_RUNNER)
+    def test_apply_profile_operation_regrid_auto_derives_trimends(
+        self, mock_class, sample_dataset
+    ):
+        """trimends passed to runner.regrid() is derived from trim_start/trim_end."""
+        mock_runner = MagicMock()
+        mock_runner.finalize.return_value = sample_dataset
+        mock_runner.get_pipeline_report.return_value = MagicMock()
+        mock_runner.statistics = []
+        mock_runner.modifications = []
+        mock_class.return_value = mock_runner
+
+        proc = ProcessedDataset(sample_dataset)
+        # sample_dataset has 100 time steps; trim_start=10, trim_end=5
+        proc.apply_profile_operation(regrid=True, trim_start=10, trim_end=5)
+
+        kw = mock_runner.regrid.call_args.kwargs
+        assert kw["trimends"] == (10, 95)  # (start_idx, n_ens - trim_end)
+
+    @patch(PROFILE_OPERATION_RUNNER)
+    def test_apply_profile_operation_regrid_trimends_none_when_no_trim(
+        self, mock_class, sample_dataset
+    ):
+        """trimends is None when neither trim_start nor trim_end is set."""
+        mock_runner = MagicMock()
+        mock_runner.finalize.return_value = sample_dataset
+        mock_runner.get_pipeline_report.return_value = MagicMock()
+        mock_runner.statistics = []
+        mock_runner.modifications = []
+        mock_class.return_value = mock_runner
+
+        proc = ProcessedDataset(sample_dataset)
+        proc.apply_profile_operation(regrid=True)
+
+        kw = mock_runner.regrid.call_args.kwargs
+        assert kw["trimends"] is None
 
     @patch(PROFILE_OPERATION_RUNNER)
     def test_apply_config_forwards_extra_cells_to_runner(


### PR DESCRIPTION
## Summary

  ### Bug fix
  - Fix trimends slice indices in the Streamlit save path — was passing raw
    trim counts as slice positions instead of computing start/end indices

  ### `apply_profile_operation` and `ProcessingConfig`
  - Expose full `regrid()` options in `apply_profile_operation`:
    `regrid_method`, `regrid_end_cell_option`, `regrid_boundary_limit`
  - Add `regrid_end_cell_option_PT` and `regrid_boundary_limit_PT` fields to
    `ProcessingConfig` with `from_ini`/`to_ini` round-trip support
  - `apply_config` updated to forward the new fields to `apply_profile_operation`

  ### Package versioning
  - Replace all hardcoded version strings in `core.py` and `__init__.py` with
    `importlib.metadata.version("pyadps")` — single source of truth from
    `pyproject.toml`, consistent with `binary_reader.py`

  ### Streamlit UI (`06_Profile_Operations.py`)
  - Replace Trim Ends sliders with `number_input` widgets using absolute
    first/last valid ensemble indices (more practical for large deployments)
  - Add `_trim_has_effect`, `_trim_to_counts`, `_trim_trimends` helpers to
    centralise index↔count conversion across all tabs
  - Change mask heatmap colorscale from greyscale to white/red for dark-theme
    legibility (valid = white, masked = red)
  - Add axis borders to all plot functions
  - Remove dead `plot_mask_comparison` function

  ### Tests
  - 9 new tests for regrid option forwarding and trimends auto-derivation in
    `test_core.py`
  - `test_06_Profile_Operations.py` updated: slider tests replaced with
    `number_input` equivalents, new `TestTrimHelpers` class covering all three
    helper functions, `plot_mask_comparison` tests removed — 156 tests, 100%
    page coverage