### PR TITLE
docs: add Auto Processing section, showcase regrid in chaining example

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,21 @@ proc.velocity_to_netcdf('velocity.nc', units='cm/s')
 proc.export_config('config.ini')
 ```
 
+### Auto Processing
+
+Re-run a processing workflow from a saved `config.ini` file — useful for
+batch reprocessing with adjusted thresholds.
+
+```python
+from pyadps.processing.autoprocess import autoprocess
+
+result = autoprocess(
+    config_file_or_object='config.ini',
+    binary_file_path='deployment.000',
+    save_netcdf=True,
+)
+```
+
 For the complete guide see the [documentation](https://pyadps.readthedocs.io).
 
 ## License

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -117,7 +117,7 @@ result = (
     .apply_time_axis(snap=True, snap_freq='h')
     .apply_sensor_health(roll=True, roll_threshold=15.0)
     .apply_signal_quality(correlation=64, echo_intensity=40)
-    .apply_profile_operation(cut_bins_side_lobe=True, water_depth=50.0)
+    .apply_profile_operation(cut_bins_side_lobe=True, regrid=True)
     .apply_velocity_check(cutoff_u=2500, cutoff_v=2500, cutoff_w=500)
     .finalize()
 )


### PR DESCRIPTION
README: document autoprocess() for re-running a workflow from a saved config.ini file.

quickstart.md: swap water_depth for regrid=True in the method-chaining example to demonstrate regridding in the fluent API.